### PR TITLE
fix: Remove strtolower() function for header value assignment

### DIFF
--- a/src/Traits/Request.php
+++ b/src/Traits/Request.php
@@ -148,7 +148,7 @@ trait Request
     public function setHeader(string $key, string $value, $strtolower = true)
     {
         if ($strtolower) {
-            $this->header[strtolower($key)] = strtolower($value);
+            $this->header[strtolower($key)] = $value;
         } else {
             $this->header[$key] = $value;
         }


### PR DESCRIPTION
HTTP信息头的值是大小写敏感的，因此不应该对其进行大小写转换操作。